### PR TITLE
Fixed broken icons from sprites font

### DIFF
--- a/http/index.html
+++ b/http/index.html
@@ -50,7 +50,7 @@
 			debug:true,
 			baseUrl:"/flow/flow-ux/",
 			theme:{
-				iconPath:"/resources/extern/fonts/fontawesome/sprites/",
+				iconPath:"/karlsen-ux/resources/extern/fonts/fontawesome/sprites/",
 				iconFile:"light",
 				icons:{
 					//"info-circle": "light:acorn"


### PR DESCRIPTION
If running without rewrite rules, several icons loaded from the sprites font are currently broken in web wallet. This pull requests fixes it. The fix has no negative impact in desktop wallet. It closes #5.